### PR TITLE
Add monitor names for API parameter(s)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -58,3 +58,91 @@ Returns:
   }
 ]
 ```
+
+### Values for monitor parameter
+
+The following values are available for the `m[]` parameter(s):
+
+**Metrist**
+
+* `metrist` - Metrist (yes, monitor Metrist with Metrist!)
+
+**AWS**
+
+* `awscloudfront` - AWS Cloudfront
+* `awscloudwatch` - AWS CloudWatch
+* `cognito` - AWS Cognito
+* `ec2` - AWS EC2
+* `awsecs` - AWS ECS (Fargate)
+* `awseks` - AWS EKS
+* `awselb` - AWS ELB
+* `awsiam` - AWS IAM
+* `kinesis` - AWS Kinesis
+* `awslambda` - AWS Lambda
+* `awsrds` - AWS RDS
+* `awsroute53` - AWS Route53
+* `s3` - AWS S3
+* `ses` - AWS SES
+* `sqs` - AWS SQS
+
+**Azure**
+
+* `azureaks` - Azure AKS
+* `azuread` - Azure Active Directory
+* `azureappservice` - Azure App Service
+* `azureblob` - Azure Blob Storage
+* `azurecdn` - Azure CDN
+* `azuredb` - Azure Cosmos DB
+* `azuredevopsartifacts` - Azure DevOps Artifacts
+* `azuredevopsboards` - Azure DevOps Boards
+* `azuredevopspipelines` - Azure DevOps Pipelines
+* `azuredevopsrepos` - Azure DevOps Repos
+* `azuredevopstestplans` - Azure DevOps Test Plans
+* `azurefncs` - Azure Functions
+* `azuremonitor` - Azure Monitor
+* `azuresql` - Azure SQL
+* `azurevm` - Azure Virtual Machines
+
+**Google Cloud Platform**
+
+* `gcpcloudstorage` - GCP Cloud Storage
+* `gcpcomputeengine` - GCP Compute Engine
+* `gcpgke` - GCP GKE
+
+**APIs**
+
+* `avalara` - Avalara (AvaTax)
+* `bambora` - Bambora
+* `braintree` - Braintree
+* `easypost` - EasyPost
+* `fastly` - Fastly
+* `github` - GitHub
+* `gcal` - Google Calendar
+* `gmaps` - Google Maps
+* `hubspot` - HubSpot
+* `moneris` - Moneris
+* `pubnub` - PubNub
+* `sendgrid` - SendGrid
+* `stripe` - Stripe
+
+**Infrastructure**
+
+* `cloudflare` - Cloudflare
+* `heroku` - Heroku
+* `snowflake` - Snowflake
+
+**SaaS**
+
+* `authzero` - Auth0
+* `circleci` - CircleCI
+* `datadog` - Datadog
+* `jira` - Jira
+* `npm` - NPM
+* `nuget` - NuGet
+* `pagerduty` - PagerDuty
+* `sentry` - Sentry
+* `slack` - Slack
+* `trello` - Trello
+* `twiliovid` - Twilio Video
+* `zendesk` - Zendesk
+* `zoom` - Zoom


### PR DESCRIPTION
Adds logical monitor names for the `m[]` parameter(s).