### PR TITLE
Fix in process link

### DIFF
--- a/docs/orchestrator-ebpf-plugin.md
+++ b/docs/orchestrator-ebpf-plugin.md
@@ -4,7 +4,7 @@
 
 The Orchestrator eBPF Plugin uses the Linux kernel's [eBPF](https://ebpf.io/) functionality to help discover all
 outgoing API calls. Any call that a monitored node makes is sent to the configured Orchestrator's endpoint for
-[In-process forwarding](./agent-source-code#in-process-forwarding) for further processing. Unknown API calls
+[In-process forwarding](../agent-source-code#in-process-forwarding) for further processing. Unknown API calls
 will be logged (both by Orchestrator as well as by this plugin) and known API calls will be converted into
 Service/check pairs and sent to the Metrist backend as regular monitoring metrics.
 


### PR DESCRIPTION
Fixes the link to the agent source code in process heading.